### PR TITLE
fix: cannot find 'CIImage' in scope

### DIFF
--- a/ios/FoodClassifier.swift
+++ b/ios/FoodClassifier.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Vision
 import CoreML
+import CoreImage
 
 @objc(FoodClassifier)
 class FoodClassifier: NSObject {


### PR DESCRIPTION
fix build error with `CoreMLImageClassifierSample/ios/FoodClassifier.swift:40:25: cannot find 'CIImage' in scope`